### PR TITLE
Check duplicate addresses #4

### DIFF
--- a/contracts/Move.lock
+++ b/contracts/Move.lock
@@ -29,8 +29,8 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x279056dd817675193198b288be2cf2bae3c8ddf99b10ca353263d19449444e0e"
-latest-published-id = "0x279056dd817675193198b288be2cf2bae3c8ddf99b10ca353263d19449444e0e"
+original-published-id = "0x0ad9b74d8ebb2c14edc0b79fc01edd1639813d8ceef1a038135c519e32e19572"
+latest-published-id = "0x0ad9b74d8ebb2c14edc0b79fc01edd1639813d8ceef1a038135c519e32e19572"
 published-version = "1"
 
 [env.devnet]

--- a/contracts/Move.lock
+++ b/contracts/Move.lock
@@ -29,8 +29,8 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x36e3ec59a7c1058c24bf81f818cad1769629f4cfc9329ab38a0e7683dd3783b6"
-latest-published-id = "0x36e3ec59a7c1058c24bf81f818cad1769629f4cfc9329ab38a0e7683dd3783b6"
+original-published-id = "0x279056dd817675193198b288be2cf2bae3c8ddf99b10ca353263d19449444e0e"
+latest-published-id = "0x279056dd817675193198b288be2cf2bae3c8ddf99b10ca353263d19449444e0e"
 published-version = "1"
 
 [env.devnet]

--- a/contracts/sources/raffle.move
+++ b/contracts/sources/raffle.move
@@ -11,6 +11,9 @@ use sui::vec_set::{Self, VecSet};
 
 use std::string::{String};
 
+// === Errors ===
+
+const EDuplicateAddress: u64 = 1;
 
 // === Structs ===
 
@@ -57,6 +60,7 @@ entry fun participate(
     raffle: &mut Raffle,
     ctx: & TxContext
 ){
+    assert!(raffle.participants.contains(&ctx.sender()) == false, EDuplicateAddress);
     raffle.participants.insert(ctx.sender())
 }
 
@@ -69,10 +73,6 @@ entry fun run(
     let winner_index = random_generator.generate_u64_in_range(
         0, vec_set::size(&raffle.participants) - 1
     );
-    // raffle.winners.insert(raffle.participants[winner_index]);
     let addr = raffle.participants.keys();
     raffle.winners.insert(addr[winner_index]);
-    // let vec = raffle.participants.into_keys();
-    // let winner_address = vec[winner_index];
-    // raffle.winners.insert(winner_address);
 }

--- a/contracts/sources/raffle.move
+++ b/contracts/sources/raffle.move
@@ -3,11 +3,11 @@ module suipstakes::raffle;
 // === Imports ===
 
 use sui::tx_context::{Self, TxContext};
-use sui::table_vec::{Self, TableVec};
 use sui::transfer;
 use sui::package;
 use sui::display;
 use sui::random::{Random, new_generator};
+use sui::vec_set::{Self, VecSet};
 
 use std::string::{String};
 
@@ -25,8 +25,8 @@ public struct Raffle has key {
     max_participants: u32,
     start_timestamp: u64,
     end_timestamp: u64,
-    participants: TableVec<address>,
-    winners: TableVec<address>,
+    participants: VecSet<address>,
+    winners: VecSet<address>,
 }
 
 // === Functions ===
@@ -40,8 +40,8 @@ entry fun create(
         id: object::new(ctx),
         title,
         description,
-        participants: table_vec::empty(ctx),
-        winners: table_vec::empty(ctx),
+        participants: vec_set::empty<address>(),
+        winners: vec_set::empty<address>(),
         //values are for test and need to be fixed
         prize_in_sui: 100000000,
         min_participants: 1,
@@ -57,7 +57,7 @@ entry fun participate(
     raffle: &mut Raffle,
     ctx: & TxContext
 ){
-    raffle.participants.push_back(ctx.sender())
+    raffle.participants.insert(ctx.sender())
 }
 
 entry fun run(
@@ -67,7 +67,12 @@ entry fun run(
 ) {
     let mut random_generator = random.new_generator(ctx);
     let winner_index = random_generator.generate_u64_in_range(
-        0, table_vec::length(&raffle.participants) - 1
+        0, vec_set::size(&raffle.participants) - 1
     );
-    raffle.winners.push_back(raffle.participants[winner_index as u64]);
+    // raffle.winners.insert(raffle.participants[winner_index]);
+    let addr = raffle.participants.keys();
+    raffle.winners.insert(addr[winner_index]);
+    // let vec = raffle.participants.into_keys();
+    // let winner_address = vec[winner_index];
+    // raffle.winners.insert(winner_address);
 }


### PR DESCRIPTION
- 抽選イベント参加者のアドレス保持に`table_vec`を利用していたが`vec_set`への切り替え
- 同一アドレスでの2重登録が出来ないように調整


close #4 