### PR TITLE
Select multiple winners #5

### DIFF
--- a/contracts/Move.lock
+++ b/contracts/Move.lock
@@ -29,8 +29,8 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x0ad9b74d8ebb2c14edc0b79fc01edd1639813d8ceef1a038135c519e32e19572"
-latest-published-id = "0x0ad9b74d8ebb2c14edc0b79fc01edd1639813d8ceef1a038135c519e32e19572"
+original-published-id = "0x57c4346f7f0e3ebe364d9a305f55522266994091266e5b56a1a63be0f9f463f5"
+latest-published-id = "0x57c4346f7f0e3ebe364d9a305f55522266994091266e5b56a1a63be0f9f463f5"
 published-version = "1"
 
 [env.devnet]

--- a/contracts/Move.lock
+++ b/contracts/Move.lock
@@ -29,8 +29,8 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x57c4346f7f0e3ebe364d9a305f55522266994091266e5b56a1a63be0f9f463f5"
-latest-published-id = "0x57c4346f7f0e3ebe364d9a305f55522266994091266e5b56a1a63be0f9f463f5"
+original-published-id = "0x4224f46e84975e9f7eea9971258313f43a5245cab713c61171feb226239e1b98"
+latest-published-id = "0x4224f46e84975e9f7eea9971258313f43a5245cab713c61171feb226239e1b98"
 published-version = "1"
 
 [env.devnet]

--- a/contracts/sources/raffle.move
+++ b/contracts/sources/raffle.move
@@ -52,7 +52,7 @@ entry fun create(
         max_participants: 100,
         start_timestamp: 12345,
         end_timestamp: 12345,
-        number_of_winners: 3
+        number_of_winners: 2
     };
 
     transfer::share_object(raffle);
@@ -72,9 +72,14 @@ entry fun run(
     ctx: &mut TxContext
 ) {
     let mut random_generator = random.new_generator(ctx);
-    let winner_index = random_generator.generate_u64_in_range(
-        0, vec_set::size(&raffle.participants) - 1
-    );
-    let addr = raffle.participants.keys();
-    raffle.winners.insert(addr[winner_index]);
+    let mut i = 0;
+    while (i < raffle.number_of_winners) {
+        let winner_index = random_generator.generate_u64_in_range(0, vec_set::size(&raffle.participants) -1);
+        let address_list = raffle.participants.keys();
+        let winner_address = address_list[winner_index];
+        raffle.winners.insert(winner_address);
+        raffle.participants.remove(&winner_address);
+
+        i = i + 1;
+    }
 }

--- a/contracts/sources/raffle.move
+++ b/contracts/sources/raffle.move
@@ -30,6 +30,7 @@ public struct Raffle has key {
     end_timestamp: u64,
     participants: VecSet<address>,
     winners: VecSet<address>,
+    number_of_winners: u8,
 }
 
 // === Functions ===
@@ -51,6 +52,7 @@ entry fun create(
         max_participants: 100,
         start_timestamp: 12345,
         end_timestamp: 12345,
+        number_of_winners: 3
     };
 
     transfer::share_object(raffle);

--- a/contracts/sources/raffle.move
+++ b/contracts/sources/raffle.move
@@ -30,7 +30,7 @@ public struct Raffle has key {
     end_timestamp: u64,
     participants: VecSet<address>,
     winners: VecSet<address>,
-    number_of_winners: u8,
+    number_of_winners: u16,
 }
 
 // === Functions ===
@@ -74,7 +74,10 @@ entry fun run(
     let mut random_generator = random.new_generator(ctx);
     let mut i = 0;
     while (i < raffle.number_of_winners) {
-        let winner_index = random_generator.generate_u64_in_range(0, vec_set::size(&raffle.participants) -1);
+        let winner_index = random_generator.generate_u64_in_range(
+            0, 
+            raffle.participants.size() -1
+        );
         let address_list = raffle.participants.keys();
         let winner_address = address_list[winner_index];
         raffle.winners.insert(winner_address);


### PR DESCRIPTION
- 当選者数を示すフィールド(number_of_winners) を`public struct Raffle`へ追加
- 抽選ロジックの作成
  - `entry fun run`で実装
  - https://github.com/fukaeridesui/suipstakes/issues/5#issuecomment-2310205882
- 当選者数に応じた当選者のアドレスを選出できるように作成
- `contracts/Move.lock`はレビュー対象外


clsoe # 5